### PR TITLE
Update assembly-format.md

### DIFF
--- a/openpublishing/demo/assembly-format.md
+++ b/openpublishing/demo/assembly-format.md
@@ -6,7 +6,7 @@ Assemblies are used for the programs themselves as well as any dependent librari
 A .NET program can be executed as one of more assemblies, with no other required artifacts, beyond the appropriate .NET runtime.
 Native dependencies, including operating system APIs, are a separate concern and are not contained within the .NET assembly format, although are sometimes described with this format (e.g. WinRT).
 
-> Each CLI (Common language infrastructure) component carries the metadata for declarations, implementations, and references specific to that component.
+> Each CLI (Common Language Infrastructure) component carries the metadata for declarations, implementations, and references specific to that component.
 > Therefore, the component-specific metadata is referred to as component metadata, and the resulting component is said to be self-describing -- from ECMA 335 I.9.1, Components and assemblies.
 
 The format is fully specified and standardized as [ECMA 335](dotnet-standards.md)!


### PR DESCRIPTION
just a test. the change is to use capital L and I for Common Language Infrastructure).